### PR TITLE
Use correct distribution of docker repo

### DIFF
--- a/utils/bootstrap/travis_docker_install.yml
+++ b/utils/bootstrap/travis_docker_install.yml
@@ -6,7 +6,7 @@
 
 - name: Add the official docker repo
   apt_repository:
-    repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu trusty stable
+    repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable
     state: present
 
 - name: Refresh apt cache


### PR DESCRIPTION
When adding the docker apt repo, use the correct distribution based on
the installed release of the builder host.